### PR TITLE
move topic names from log4j2.xml to env.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,16 @@ and
   docker-compose down --remove-orphans
 ```
 
+You can view the Kafka Topics in the _Confluent Control Center_ at http://localhost:9021/clusters
+
+## Build and run
+1. Build the jar file with `mvn clean package`
+1. Start Kafka in docker - see above
+1. Run the jar file with `java -jar target/spring-boot-log-to-kafka-example-1.0-SNAPSHOT.jar`
+  1. or Run in IDE
+
 ## To do
-1) Inject spring properties for the kafka host names and kafka topic names
+1) Inject spring properties for the kafka host names and kafka topic names - topic names are currently stored in `env.properties` which are injected into `log4j2.xml`
 1) include the host name in  the log message.  Cannot be done in the pattern
 1) Understand what behavior should be if Appender cannot reach the broker
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.6.2</version>
     </parent>
 
     <groupId>io.woolford</groupId>
@@ -55,7 +53,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/woolford/audit/AuditMessageGenerator.java
+++ b/src/main/java/io/woolford/audit/AuditMessageGenerator.java
@@ -1,12 +1,7 @@
 package io.woolford.audit;
 
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,12 +26,12 @@ public class AuditMessageGenerator {
 
         // If we exposed log4j2 instead of Slf4j then we could have used ObjectMessage
         String jsonString = AuditMessage.builder()
-            .message("Event Message Generated")
-            .index(index)
-            .eventTimestamp(Instant.now())
-            .build()
-            .toJSON();
-        
+                .message("Event Message Generated")
+                .index(index)
+                .eventTimestamp(Instant.now())
+                .build()
+                .toJSON();
+
         // show audit and regular audit based on the presence of Audit Marker
         logger.info(AuditMarker.getMarker(), jsonString);
     }

--- a/src/main/resources/env.properties
+++ b/src/main/resources/env.properties
@@ -1,0 +1,4 @@
+bootstrap.servers=localhost:9092
+audit.logmarker=AuditRecord
+kafka.topic.audit=audit
+kafka.topic.logs=logs

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info" name="spring-boot-log-to-kafka-example" packages="io.woolford">
     <Properties>
-        <Property name="bootstrap.servers">localhost:9092</Property>
-        <Property name="audit.logmarker">AuditRecord</Property>
-        <Property name="kafka.topic.audit">audit</Property>
-        <Property name="kafka.topic.logs">logs</Property>
+        <Property name="bootstrap.servers">${bundle:env:bootstrap.servers}</Property>
+        <Property name="audit.logmarker">${bundle:env:audit.logmarker}</Property>
+        <Property name="kafka.topic.audit">${bundle:env:kafka.topic.audit}</Property>
+        <Property name="kafka.topic.logs">${bundle:env:kafka.topic.logs}</Property>
     </Properties>
 
-    <!-- Log4J2 JSONLayout objectMessageAsJsonObject not exposed through SLF4j 10/2020 --> 
+    <!-- Log4J2 JSONLayout objectMessageAsJsonObject not exposed through SLF4j 10/2020 -->
     <Appenders>
         <!-- Kafka Audit Appender only forwards messages with the "AuditRecord" marker -->
         <!-- We put only the message here assuming it will be formatted json-->
         <Kafka name="kafkaAuditAppender" topic="${kafka.topic.audit}">
-            <PatternLayout pattern="%message%n"/>
+            <PatternLayout pattern="%message%n" />
             <Property name="bootstrap.servers">${bootstrap.servers}</Property>
-            <MarkerFilter marker="${audit.logmarker}" onMatch="ACCEPT" onMismatch="DENY"/>
+            <MarkerFilter marker="${audit.logmarker}" onMatch="ACCEPT" onMismatch="DENY" />
         </Kafka>
 
         <!-- https://logging.apache.org/log4j/2.x/manual/configuration.html#PropertySubstitution -->
@@ -26,30 +26,30 @@
         <Kafka name="kafkaLogAppender" topic="${kafka.topic.logs}">
             <JSONLayout />
             <Property name="bootstrap.servers">${bootstrap.servers}</Property>
-            <MarkerFilter marker="${audit.logmarker}" onMatch="DENY" onMismatch="ACCEPT"/>
+            <MarkerFilter marker="${audit.logmarker}" onMatch="DENY" onMismatch="ACCEPT" />
         </Kafka>
 
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} stdout %highlight{%-5p} [%-7t] %F:%L - %m%n"/>
-            <MarkerFilter marker="${audit.logmarker}" onMatch="DENY" onMismatch="ACCEPT"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} stdout %highlight{%-5p} [%-7t] %F:%L - %m%n" />
+            <MarkerFilter marker="${audit.logmarker}" onMatch="DENY" onMismatch="ACCEPT" />
         </Console>
 
         <Console name="stderr" target="SYSTEM_ERR">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %highlight{stderr} %highlight{%-5p} [%-7t] %F:%L - %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %highlight{stderr} %highlight{%-5p} [%-7t] %F:%L - %m%n" />
             <Filters>
                 <ThresholdFilter level="WARN" onMatch="ACCEPT" />
-                <MarkerFilter marker="${audit.logmarker}" onMatch="DENY" onMismatch="ACCEPT"/>
+                <MarkerFilter marker="${audit.logmarker}" onMatch="DENY" onMismatch="ACCEPT" />
             </Filters>
         </Console>
 
     </Appenders>
     <Loggers>
         <Root level="INFO">
-            <AppenderRef ref="kafkaAuditAppender"/>
-            <AppenderRef ref="kafkaLogAppender"/>
+            <AppenderRef ref="kafkaAuditAppender" />
+            <AppenderRef ref="kafkaLogAppender" />
             <!--stdout/stderr included for testing Oozie log4j edits-->
-            <AppenderRef ref="stdout"/>
-            <AppenderRef ref="stderr"/>
+            <AppenderRef ref="stdout" />
+            <AppenderRef ref="stderr" />
         </Root>
         <!-- Do not let org.apache.kafka log to a Kafka appender on DEBUG level. That will cause recursive logging -->
         <Logger name="org.apache.kafka" level="warn" />


### PR DESCRIPTION
Extract topic names from log4j2.xml.
Update spring boot version.  
Pulls in the latest log4j2 with CVE fixes. 
Removed unnecessary imports.